### PR TITLE
Update Recipes_Change.xml

### DIFF
--- a/1.3/Patches/Recipes_Change.xml
+++ b/1.3/Patches/Recipes_Change.xml
@@ -110,7 +110,7 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>/Defs/ThingDef [defName = "Gun_EmpLauncher"]/costList</xpath>
 		<value>
-			<VMEu_Lithium>8.5</VMEu_Lithium>
+			<VMEu_Lithium>8</VMEu_Lithium>
 		</value>
 	</Operation>
 	


### PR DESCRIPTION
Non-integer material costs are invalid and will be parsed as integers by RimWorld automatically, generating a yellow error.